### PR TITLE
Add the missing `Dispose()` to `IDSS` to avoid context leaks

### DIFF
--- a/altdss/dsslib.go
+++ b/altdss/dsslib.go
@@ -9129,6 +9129,23 @@ func (dss *IDSS) Init(ctxPtr unsafe.Pointer) {
 	dss.ZIP.Init(ctx)
 }
 
+// Dispose an existing DSS engine context.
+//
+// Use this only with the contexts created by the NewContext() function.
+// The prime instance cannot be disposed by the user.
+//
+// (API Extension)
+func (dss *IDSS) Dispose() {
+	primePtr := C.ctx_Get_Prime()
+
+	if (primePtr == dss.ctxPtr) || (nil == dss.ctxPtr) {
+		return
+	}
+
+	C.ctx_Dispose(dss.ctxPtr)
+	dss.ctxPtr = nil
+}
+
 // Creates a new DSS engine context.
 // A DSS Context encapsulates most of the global state of the original OpenDSS engine,
 // allowing the user to create multiple instances in the same process. By creating contexts

--- a/examples/ctx_disposal.go
+++ b/examples/ctx_disposal.go
@@ -1,0 +1,24 @@
+// Added to reproduce and test issue 48 (missing Dispose causing leak)
+// https://github.com/dss-extensions/dss-extensions/issues/48
+package main
+
+import (
+	"log"
+	"runtime"
+	"time"
+	"github.com/dss-extensions/altdss-go/altdss"
+)
+
+func main() {
+	dss := altdss.IDSS{}
+	dss.Init(nil)
+	for i := 0; i < 10000; i++ {
+		time.Sleep(1 * time.Millisecond)
+		ctx, err := dss.NewContext()
+		ctx.Dispose()
+		if err != nil {
+			log.Fatal(err)
+		}
+		runtime.GC()
+	}
+}

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -36,6 +36,7 @@ func main() {
 		println(i, names[i], vmag[i]/1000, cvolts[i])
 	}
 	dss2, err := dss.NewContext()
+	defer dss2.Dispose()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Updated the example and kept the reproducer in `examples/ctx_disposal.go`

Ref: https://github.com/dss-extensions/dss-extensions/issues/48